### PR TITLE
Added a simple migration hook for dealing with property changes to serialized objects

### DIFF
--- a/FastCoder/FastCoder.h
+++ b/FastCoder/FastCoder.h
@@ -40,11 +40,11 @@ extern NSString *const FastCodingException;
 @interface NSObject (FastCoding)
 
 + (NSArray *)fastCodingKeys;
-+ (NSSet *)codingKeysRequiringMigration;
++ (NSSet *)fastCodingKeysRequiringMigration;
 
 - (id)awakeAfterFastCoding;
 - (Class)classForFastCoding;
-- (void)migrateValue:(id)value forCodingKey:(NSString *)codingKey;
+- (void)migrateValue:(id)value forFastCodingKey:(NSString *)codingKey;
 
 @end
 

--- a/FastCoder/FastCoder.m
+++ b/FastCoder/FastCoder.m
@@ -510,9 +510,9 @@ static id FCReadObjectInstance(NSUInteger *offset, const void *input, NSUInteger
     for (__unsafe_unretained NSString *key in definition.propertyKeys)
     {
 		id value = FCReadObject(offset, input, total, cache);
-		if ([[[object class] codingKeysRequiringMigration] containsObject:key])
+		if ([[[object class] fastCodingKeysRequiringMigration] containsObject:key])
 		{
-			[object migrateValue:value forCodingKey:key];
+			[object migrateValue:value forFastCodingKey:key];
 		}
 		else
 		{
@@ -886,7 +886,7 @@ CFHashCode FCDictionaryHashCallback(const void* value)
     return codableKeys;
 }
 
-+ (NSSet *)codingKeysRequiringMigration
++ (NSSet *)fastCodingKeysRequiringMigration
 {
 	return nil;
 }
@@ -901,7 +901,7 @@ CFHashCode FCDictionaryHashCallback(const void* value)
     return [self classForCoder];
 }
 
-- (void)migrateValue:(id)value forCodingKey:(NSString *)codingKey
+- (void)migrateValue:(id)value forFastCodingKey:(NSString *)codingKey
 {
 	
 }


### PR DESCRIPTION
This is really simple, but worked. Some sort of migration system is pretty critical for me because I am using FastCoding with YapDatabase and so the objects that are being serialized are my actual core model objects, and I need to be able to make changes to them and migrate from older serialized versions of the data.
