### PR TITLE
Import CoreGraphics when building for iOS

### DIFF
--- a/FastCoder/FastCoder.m
+++ b/FastCoder/FastCoder.m
@@ -33,6 +33,9 @@
 #import "FastCoder.h"
 #import <objc/message.h>
 
+#if TARGET_OS_IPHONE
+@import CoreGraphics;
+#endif
 
 #import <Availability.h>
 #if __has_feature(objc_arc)


### PR DESCRIPTION
Several types that are required by FastCoding are not included in
Foundation on iOS:
- `CGFloat`
- `CGPoint`
- `CGSize`
- `CGRect`
- `CGAffineTransform`

I believe the current FastCoder examples compile because the default
.pch for iOS applications includes UIKit. I'm attempting to include
FastCoder in a static library and it will not build. This change will
perform a module import of CoreGraphics when building for iOS to resolve
compile time errors.

For compatibility reasons, an `#import` may be preferable to an `@import`,
but this seemed to make the most sense for my purposes.
