### PR TITLE
Bug fix: Properly encode class type of NSMutableIndexSet

### DIFF
--- a/FastCoder/FastCoder.m
+++ b/FastCoder/FastCoder.m
@@ -967,7 +967,7 @@ CFHashCode FCDictionaryHashCallback(const void* value)
         rangeCount += 1;
     }];
 
-    FCWriteUInt32(FCTypeIndexSet, output);
+    FCWriteUInt32((mutable ? FCTypeMutableIndexSet : FCTypeIndexSet), output);
     FCWriteUInt32(rangeCount, output);
     [self enumerateRangesUsingBlock:^(NSRange range, BOOL *stop) {
         FCWriteUInt32(range.location, output);


### PR DESCRIPTION
Bug fix: `NSMutableIndexSet`s were being encoded as non-mutable `NSIndexSet`s
