### PR TITLE
Write stringCount into intended bytes

### DIFF
--- a/FastCoder/FastCoder.m
+++ b/FastCoder/FastCoder.m
@@ -1189,7 +1189,7 @@ static void FCWriteObject(__unsafe_unretained id object, __unsafe_unretained FCN
           
             //set string count
             uint32_t stringCount = (uint32_t)[stringCache count];
-            [output replaceBytesInRange:NSMakeRange(sizeof(header) + sizeof(uint32_t), sizeof(uint32_t)) withBytes:&stringCount];
+            [output replaceBytesInRange:NSMakeRange(sizeof(header) + 2 * sizeof(uint32_t), sizeof(uint32_t)) withBytes:&stringCount];
             
             return output;
         }


### PR DESCRIPTION
Else stringCount would overwrite the bytes classClount previously had been written to and the bytes intended for stringCount would stay zero.
