### PR TITLE
Include NSMutableString in supported classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ FastCoding supports the following class types natively:
         CGAffineTransform
         CATransform3D
     NSString
+    NSMutableString
     NSArray
     NSMutableArray
     NSDictionary


### PR DESCRIPTION
All other class (NSArray, NSDictionary etc.) have their mutable counterparts mentioned
