### PR TITLE
tvOS support added to podspec

### DIFF
--- a/FastCoding.podspec.json
+++ b/FastCoding.podspec.json
@@ -13,6 +13,7 @@
   "requires_arc": false,
   "platforms": {
     "ios": "4.3",
+    "tvos": "9.0",
     "osx": "10.6"
   }
 }


### PR DESCRIPTION
I've figured out that FastCoding is working well on tvOS without any changes in code. So I propose to add tvOS platform to podspec.