### PR TITLE
Released object crash

### DIFF
--- a/FastCoder/FastCoder.m
+++ b/FastCoder/FastCoder.m
@@ -230,12 +230,12 @@ typedef id FCTypeConstructor(FCNSDecoder *);
 
 static Boolean FCEqualityCallback(const void *value1, const void *value2)
 {
-    return (Boolean)[(id)value1 isEqual:(id)value2];
+    return (Boolean)[(__bridge id)value1 isEqual:(__bridge id)value2];
 }
 
 static CFHashCode	FCHashCallback(const void *value)
 {
-    return [(id)value hash];
+    return [(__bridge id)value hash];
 }
 
 static inline NSUInteger FCCacheParsedObject(__unsafe_unretained id object, __unsafe_unretained NSData *cache)

--- a/FastCoder/FastCoder.m
+++ b/FastCoder/FastCoder.m
@@ -866,17 +866,7 @@ static id FCReadNSCodedObject(__unsafe_unretained FCNSDecoder *decoder)
     }
     else
     {
-        const CFDictionaryKeyCallBacks stringKeyCallbacks =
-        {
-            0,
-            NULL,
-            NULL,
-            NULL,
-            FCEqualityCallback,
-            FCHashCallback
-        };
-        
-        __autoreleasing id properties = CFBridgingRelease(CFDictionaryCreateMutable(NULL, 0, &stringKeyCallbacks, NULL));
+        __autoreleasing id properties = [NSMutableDictionary dictionary];
         decoder->_properties = properties;
     }
     while (true)


### PR DESCRIPTION
When decoding thousands of objects, it's possible for FastCoding to crash because an object has been released but messages are still being sent to it. The problematic line seems to be in `FCReadNSCodedObject`:

```
        const CFDictionaryKeyCallBacks stringKeyCallbacks =
        {
            0,
            NULL,
            NULL,
            NULL,
            FCEqualityCallback,
            FCHashCallback
        };
        
        __autoreleasing id properties = CFBridgingRelease(CFDictionaryCreateMutable(NULL, 0, &stringKeyCallbacks, NULL));
```

Changing this line to the following will stop the crash.

```
        __autoreleasing id properties = [NSMutableDictionary dictionary];
```

screenshot attached:
<img width="1440" alt="screen shot 2018-02-25 at 6 53 46 pm" src="https://user-images.githubusercontent.com/251087/36648826-c5a17e72-1a5d-11e8-8791-5401934dd08a.png">
