### PR TITLE
Fix NSDate precision loss causing -isEqualToDate: to fail

### DIFF
--- a/FastCoder/FastCoder.m
+++ b/FastCoder/FastCoder.m
@@ -1,7 +1,7 @@
 //
 //  FastCoding.m
 //
-//  Version 3.2.2
+//  Version 3.3
 //
 //  Created by Nick Lockwood on 09/12/2013.
 //  Copyright (c) 2013 Charcoal Design
@@ -61,7 +61,7 @@ NSString *const FastCodingException = @"FastCodingException";
 
 static const uint32_t FCIdentifier = 'FAST';
 static const uint16_t FCMajorVersion = 3;
-static const uint16_t FCMinorVersion = 2;
+static const uint16_t FCMinorVersion = 3;
 
 
 typedef struct
@@ -191,6 +191,7 @@ typedef id FCTypeConstructor(FCNSDecoder *);
 {
     
 @public
+    FCHeader _header;
     NSUInteger *_offset;
     const void *_input;
     NSUInteger _total;
@@ -655,7 +656,8 @@ static id FCReadDate(__unsafe_unretained FCNSDecoder *decoder)
 {
     FC_ALIGN_INPUT(NSTimeInterval, *decoder->_offset);
     FC_READ_VALUE(NSTimeInterval, *decoder->_offset, decoder->_input, decoder->_total);
-    __autoreleasing NSDate *date = [NSDate dateWithTimeIntervalSince1970:value];
+    BOOL since1970 = (decoder->_header.majorVersion == 3 && decoder->_header.minorVersion < 3); // from 3.0 to 3.2
+    __autoreleasing NSDate *date = (since1970) ? [NSDate dateWithTimeIntervalSince1970:value] : [NSDate dateWithTimeIntervalSinceReferenceDate:value];
     FCCacheParsedObject(date, decoder->_objectCache);
     return date;
 }
@@ -944,6 +946,7 @@ id FCParseData(NSData *data, FCTypeConstructor *constructors[])
     //create decoder
     NSUInteger offset = sizeof(header);
     FCNSDecoder *decoder = FC_AUTORELEASE([[FCNSDecoder alloc] init]);
+    decoder->_header = header;
     decoder->_constructors = constructors;
     decoder->_input = input;
     decoder->_offset = &offset;
@@ -1701,7 +1704,7 @@ static void FCWriteObject(__unsafe_unretained id object, __unsafe_unretained FCN
     if (FCWriteObjectAlias(self, coder)) return;
     FCCacheWrittenObject(self, coder->_objectCache);
     FCWriteType(FCTypeDate, coder->_output);
-    NSTimeInterval value = [self timeIntervalSince1970];
+    NSTimeInterval value = [self timeIntervalSinceReferenceDate];
     FC_ALIGN_OUTPUT(NSTimeInterval, coder->_output);
     [coder->_output appendBytes:&value length:sizeof(value)];
 }

--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ Load the file and save it again. Now change the macro back again.
 Release notes
 ------------------
 
+Version 3.3
+
+- Fixed precision loss when serializing NSDate objects (now using -timeIntervalSinceReferenceDate rather than -timeIntervalSince1970)
+
 Version 3.2.2
 
 - Fixed warnings on Xcode 9

--- a/Tests/UnitTests/FastCoderTests.m
+++ b/Tests/UnitTests/FastCoderTests.m
@@ -16,6 +16,7 @@
 @property (nonatomic, strong) NSString *textNew;
 @property (nonatomic, strong) NSArray *array1;
 @property (nonatomic, strong) NSArray *array2;
+@property (nonatomic, strong) NSDate *date;
 
 @end
 
@@ -32,7 +33,8 @@
         ((!self.text2 && !model.text2) || [self.text2 isEqual:model.text2]) &&
         ((!self.textNew && !model.textNew) || [self.textNew isEqual:model.textNew]) &&
         ((!self.array1 && !model.array1) || [self.array1 isEqual:model.array1]) &&
-        ((!self.array2 && !model.array2) || [self.array2 isEqual:model.array2]);
+        ((!self.array2 && !model.array2) || [self.array2 isEqual:model.array2]) &&
+        ((!self.date && !model.date) || [self.date isEqual:model.date]);
     }
     return NO;
 }
@@ -44,6 +46,7 @@
     copy.textNew = self.textNew;
     copy.array1 = self.array1;
     copy.array2 = self.array2;
+    copy.date = self.date;
     return copy;
 }
 
@@ -70,6 +73,7 @@
     model.textNew = [NSMutableString stringWithString:@"bar"];
     model.array1 = @[@"foo", @"bar"];
     model.array2 = @[@1, @2];
+    model.date = [NSDate date];
     
     //save model
     NSData *data = [FastCoder dataWithRootObject:model];
@@ -193,6 +197,18 @@
     
     //check
     XCTAssertEqualObjects([input description], [output description]);
+}
+
+- (void)testDateEquality
+{
+    NSDate *input = [NSDate dateWithTimeIntervalSinceReferenceDate:542911754.16538298];
+
+    //convert to FastCoded data
+    NSData *data = [FastCoder dataWithRootObject:input];
+    NSDate *output = [FastCoder objectWithData:data];
+
+    //check
+    XCTAssertTrue([input isEqualToDate:output]);
 }
 
 - (void)testBooleans


### PR DESCRIPTION
In a project I'm working on we noticed an issue with serializing dates. The model object in question has multiple `NSDate` objects and in its `-isEqual:` method it checks the dates by calling `-isEqualToDate`. Now one of our tests seemed to fail randomly, because `-isEqual:` returned `NO` after encoding and decoding the object using FastCoder which caused our project to do unexpected things as the object didn't really change.

Specifically, the following assertion fails:

    NSDate *input = [NSDate dateWithTimeIntervalSinceReferenceDate:542911754.16538298];
    NSDate *decodedInput = [FastCoder objectWithData:[FastCoder dataWithRootObject:input]];
    XCTAssertTrue([input isEqualToDate: decodedInput]);

This happens because `NSDate` stores `-timeIntervalSinceReferenceDate` internally rather than `-timeIntervalSince1970`. FastCoder relies on `-timeIntervalSince1970` and that causes the equality check to fail due to floating point conversion.

See `NSDate`'s implementation (decompiled using Hopper):
<img width="543" alt="timeintervalsincereferencedate" src="https://user-images.githubusercontent.com/143137/37534665-bd8bb7c4-2945-11e8-862d-a67d36dfbe90.png">
<img width="497" alt="isequaltodate" src="https://user-images.githubusercontent.com/143137/37534663-bd7073e2-2945-11e8-9fd6-cd7bda160776.png">

The actual change to fix the issue in `FCReadDate()` and `-[NSDate FC_encodeWithCoder:]` is rather simple, but in order to guarantee backwards-compatibility I had to make the version information accessible to `FCReadDate()`.

In the unit tests `-testDateEquality` should always fail without the fix while `-testChangingModel` only fails about 50% of the time depending on the current date.